### PR TITLE
update formula to support graylog v3.x

### DIFF
--- a/graylog/files/server.conf
+++ b/graylog/files/server.conf
@@ -75,96 +75,110 @@ root_email = "{{ config.graylog.root_email }}"
 # Default is UTC
 root_timezone = {{ config.graylog.root_timezone }}
 
+# Set the bin directory here (relative or absolute)
+# This directory contains binaries that are used by the Graylog server.
+# Default: bin
+bin_dir = {{ config.graylog.bin_dir }}
+
+# Set the data directory here (relative or absolute)
+# This directory is used to store Graylog server state.
+# Default: data
+data_dir = {{ config.graylog.data_dir }}
+
 # Set plugin directory here (relative or absolute)
 plugin_dir = {{ config.graylog.plugin_dir }}
 
-# REST API listen URI. Must be reachable by other Graylog server nodes if you run a cluster.
-# When using Graylog Collectors, this URI will be used to receive heartbeat messages and must be accessible for all collectors.
-# rest_listen_uri = http://127.0.0.1:9000/api/
-rest_listen_uri = {{ config.graylog.rest.listen_uri }}
+###############
+# HTTP settings
+###############
 
-# REST API transport address. Defaults to the value of rest_listen_uri. Exception: If rest_listen_uri
-# is set to a wildcard IP address (0.0.0.0) the first non-loopback IPv4 system address is used.
-# If set, this will be promoted in the cluster discovery APIs, so other nodes may try to connect on
-# this address and it is used to generate URLs addressing entities in the REST API. (see rest_listen_uri)
-# You will need to define this, if your Graylog server is running behind a HTTP proxy that is rewriting
-# the scheme, host name or URI.
-# This must not contain a wildcard address (0.0.0.0).
-#rest_transport_uri = {{ config.graylog.rest.transport_uri }}
+#### HTTP bind address
+#
+# The network interface used by the Graylog HTTP interface.
+#
+# This network interface must be accessible by all Graylog nodes in the cluster and by all clients
+# using the Graylog web interface.
+#
+# If the port is omitted, Graylog will use port 9000 by default.
+#
+# Default: 127.0.0.1:9000
+#http_bind_address = 127.0.0.1:9000
+#http_bind_address = [2001:db8::1]:9000
+http_bind_address = {{ config.graylog.http.bind_address }}
 
-# Enable CORS headers for REST API. This is necessary for JS-clients accessing the server directly.
+#### HTTP publish URI
+#
+# The HTTP URI of this Graylog node which is used to communicate with the other Graylog nodes in the cluster and by all
+# clients using the Graylog web interface.
+#
+# The URI will be published in the cluster discovery APIs, so that other Graylog nodes will be able to find and connect to this Graylog node.
+#
+# This configuration setting has to be used if this Graylog node is available on another network interface than $http_bind_address,
+# for example if the machine has multiple network interfaces or is behind a NAT gateway.
+#
+# If $http_bind_address contains a wildcard IPv4 address (0.0.0.0), the first non-loopback IPv4 address of this machine will be used.
+# This configuration setting *must not* contain a wildcard address!
+#
+# Default: http://$http_bind_address/
+#http_publish_uri = {{ config.graylog.http.publish_uri }}
+
+#### External Graylog URI
+#
+# The public URI of Graylog which will be used by the Graylog web interface to communicate with the Graylog REST API.
+#
+# The external Graylog URI usually has to be specified, if Graylog is running behind a reverse proxy or load-balancer
+# and it will be used to generate URLs addressing entities in the Graylog REST API (see $http_bind_address).
+#
+# When using Graylog Collector, this URI will be used to receive heartbeat messages and must be accessible for all collectors.
+#
+# This setting can be overriden on a per-request basis with the "X-Graylog-Server-URL" HTTP request header.
+#
+# Default: $http_publish_uri
+#http_external_uri = {{ config.graylog.http.external_uri }}
+
+#### Enable CORS headers for HTTP interface
+#
+# This is necessary for JS-clients accessing the server directly.
 # If these are disabled, modern browsers will not be able to retrieve resources from the server.
 # This is enabled by default. Uncomment the next line to disable it.
-rest_enable_cors = {{ config.graylog.rest.enable_cors }}
+http_enable_cors = {{ config.graylog.http.enable_cors }}
 
-# Enable GZIP support for REST API. This compresses API responses and therefore helps to reduce
-# overall round trip times. This is enabled by default. Uncomment the next line to enable it.
-rest_enable_gzip = {{ config.graylog.rest.enable_gzip }}
-
-# Enable HTTPS support for the REST API. This secures the communication with the REST API with
-# TLS to prevent request forgery and eavesdropping. This is disabled by default. Uncomment the
-# next line to enable it.
-#rest_enable_tls = {{ config.graylog.rest.enable_tls }}
-
-# The X.509 certificate chain file in PEM format to use for securing the REST API.
-#rest_tls_cert_file = {{ config.graylog.rest.tls_cert_file }}
-
-# The PKCS#8 private key file in PEM format to use for securing the REST API.
-#rest_tls_key_file = {{ config.graylog.rest.tls_key_file }}
-
-# The password to unlock the private key used for securing the REST API.
-#rest_tls_key_password = {{ config.graylog.rest.tls_key_password }}
+#### Enable GZIP support for HTTP interface
+#
+# This compresses API responses and therefore helps to reduce
+# overall round trip times. This is enabled by default. Uncomment the next line to disable it.
+http_enable_gzip = {{ config.graylog.http.enable_gzip }}
 
 # The maximum size of the HTTP request headers in bytes.
-#rest_max_header_size = {{ config.graylog.rest.max_header_size }}
+http_max_header_size = {{ config.graylog.http.max_header_size }}
 
-# The size of the thread pool used exclusively for serving the REST API.
-rest_thread_pool_size = {{ config.graylog.rest.thread_pool_size }}
+# The size of the thread pool used exclusively for serving the HTTP interface.
+http_thread_pool_size = {{ config.graylog.http.thread_pool_size }}
+
+################
+# HTTPS settings
+################
+
+#### Enable HTTPS support for the HTTP interface
+#
+# This secures the communication with the HTTP interface with TLS to prevent request forgery and eavesdropping.
+#
+# Default: false
+#http_enable_tls = {{ config.graylog.http.enable_tls }}
+
+# The X.509 certificate chain file in PEM format to use for securing the HTTP interface.
+#http_tls_cert_file = {{ config.graylog.http.tls_cert_file }}
+
+# The PKCS#8 private key file in PEM format to use for securing the HTTP interface.
+#http_tls_key_file = {{ config.graylog.http.tls_key_file }}
+
+# The password to unlock the private key used for securing the HTTP interface.
+#http_tls_key_password = {{ config.graylog.http.tls_key_password }}
 
 # Comma separated list of trusted proxies that are allowed to set the client address with X-Forwarded-For
 # header. May be subnets, or hosts.
+#trusted_proxies = 127.0.0.1/32, 0:0:0:0:0:0:0:1/128
 trusted_proxies = {{ config.graylog.trusted_proxies }}
-
-# Enable the embedded Graylog web interface.
-# Default: true
-web_enable = {{ config.graylog.web.enable }}
-
-# Web interface listen URI.
-# Configuring a path for the URI here effectively prefixes all URIs in the web interface. This is a replacement
-# for the application.context configuration parameter in pre-2.0 versions of the Graylog web interface.
-web_listen_uri = {{ config.graylog.web.listen_uri }}
-
-# Web interface endpoint URI. This setting can be overriden on a per-request basis with the X-Graylog-Server-URL header.
-# Default: $rest_transport_uri
-#web_endpoint_uri = {{ config.graylog.web.endpoint_uri }}
-
-# Enable CORS headers for the web interface. This is necessary for JS-clients accessing the server directly.
-# If these are disabled, modern browsers will not be able to retrieve resources from the server.
-web_enable_cors = {{ config.graylog.web.enable_cors }}
-
-# Enable/disable GZIP support for the web interface. This compresses HTTP responses and therefore helps to reduce
-# overall round trip times. This is enabled by default. Uncomment the next line to disable it.
-web_enable_gzip = {{ config.graylog.web.enable_gzip }}
-
-# Enable HTTPS support for the web interface. This secures the communication of the web browser with the web interface
-# using TLS to prevent request forgery and eavesdropping.
-# This is disabled by default. Uncomment the next line to enable it and see the other related configuration settings.
-#web_enable_tls = {{ config.graylog.web.enable_gzip }}
-
-# The X.509 certificate chain file in PEM format to use for securing the web interface.
-#web_tls_cert_file = {{ config.graylog.web.tls_cert_file }}
-
-# The PKCS#8 private key file in PEM format to use for securing the web interface.
-#web_tls_key_file = {{ config.graylog.web.tls_key_file }}
-
-# The password to unlock the private key used for securing the web interface.
-#web_tls_key_password = {{ config.graylog.web.tls_key_password }}
-
-# The maximum size of the HTTP request headers in bytes.
-#web_max_header_size = {{ config.graylog.web.max_header_size }}
-
-# The size of the thread pool used exclusively for serving the web interface.
-web_thread_pool_size = {{ config.graylog.web.thread_pool_size }}
 
 # List of Elasticsearch hosts Graylog should connect to.
 # Need to be specified as a comma-separated list of valid URIs for the http ports of your elasticsearch nodes.
@@ -248,6 +262,9 @@ rotation_strategy = {{ config.graylog.rotation_strategy }}
 #
 # ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
 #            to your previous 1.x settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 elasticsearch_max_docs_per_index = {{ config.graylog.elasticsearch.max_docs_per_index }}
 
 # (Approximate) maximum size in bytes per Elasticsearch index on disk before a new index is being created, also see
@@ -256,6 +273,9 @@ elasticsearch_max_docs_per_index = {{ config.graylog.elasticsearch.max_docs_per_
 #
 # ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
 #            to your previous 1.x settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 #elasticsearch_max_size_per_index = {{ config.graylog.elasticsearch.max_size_per_index }}
 
 # (Approximate) maximum time before a new Elasticsearch index is being created, also see
@@ -271,6 +291,9 @@ elasticsearch_max_docs_per_index = {{ config.graylog.elasticsearch.max_docs_per_
 #
 # ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
 #            to your previous 1.x settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 #elasticsearch_max_time_per_index = {{ config.graylog.elasticsearch.max_time_per_index }}
 
 # Disable checking the version of Elasticsearch for being compatible with this Graylog release.
@@ -284,7 +307,10 @@ elasticsearch_max_docs_per_index = {{ config.graylog.elasticsearch.max_docs_per_
 #
 # ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
 #            to your previous 1.x settings so they will be migrated to the database!
-elasticsearch_max_number_of_indices = {{ config.graylog.elasticsearch.max_number_of_indices }}
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+elasticsearch_max_number_of_indices = {{ config.graylog.elasticsearch.max_number_of_indices }} 
 
 # Decide what happens with the oldest indices when the maximum number of indices is reached.
 # The following strategies are availble:
@@ -293,11 +319,17 @@ elasticsearch_max_number_of_indices = {{ config.graylog.elasticsearch.max_number
 #
 # ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
 #            to your previous 1.x settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 retention_strategy = {{ config.graylog.retention_strategy }}
 
 # How many Elasticsearch shards and replicas should be used per index? Note that this only applies to newly created indices.
 # ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
 #            to your previous settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 elasticsearch_shards = {{ config.graylog.elasticsearch.shards }}
 elasticsearch_replicas = {{ config.graylog.elasticsearch.replicas }}
 
@@ -305,6 +337,9 @@ elasticsearch_replicas = {{ config.graylog.elasticsearch.replicas }}
 #
 # ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
 #            to your previous settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 elasticsearch_index_prefix = {{ config.graylog.elasticsearch.index_prefix }}
 
 # Name of the Elasticsearch index template used by Graylog to apply the mandatory index mapping.
@@ -312,6 +347,9 @@ elasticsearch_index_prefix = {{ config.graylog.elasticsearch.index_prefix }}
 #
 # ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
 #            to your previous settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 #elasticsearch_template_name = {{ config.graylog.elasticsearch.template_name }}
 
 # Do you want to allow searches with leading wildcards? This can be extremely resource hungry and should only
@@ -329,6 +367,9 @@ allow_highlighting = {{ config.graylog.allow_highlighting }}
 #
 # ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
 #            to your previous settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 elasticsearch_analyzer = {{ config.graylog.elasticsearch.analyzer }}
 
 # Global request timeout for Elasticsearch requests (e. g. during search, index creation, or index time-range
@@ -349,6 +390,11 @@ elasticsearch_request_timeout = {{ config.graylog.elasticsearch.request_timeout 
 # is being purged from the database.
 # Default: 1h
 #index_ranges_cleanup_interval = {{ config.graylog.index_ranges_cleanup_interval }}
+
+# Time interval for the job that runs index field type maintenance tasks like cleaning up stale entries. This doesn't
+# need to run very often.
+# Default: 1h
+#index_field_type_periodical_interval = {{ config.graylog.index_field_type_periodical_interval }}
 
 # Batch size for the Elasticsearch output. This is the maximum (!) number of messages the Elasticsearch output
 # module will get at once and write to Elasticsearch in a batch call. If the configured batch size has not been
@@ -497,21 +543,29 @@ mongodb_max_connections = {{ config.graylog.mongodb.max_connections }}
 # http://api.mongodb.org/java/current/com/mongodb/MongoOptions.html#threadsAllowedToBlockForConnectionMultiplier
 mongodb_threads_allowed_to_block_multiplier = {{ config.graylog.mongodb.threads_allowed_to_block_multiplier }}
 
-# Drools Rule File (Use to rewrite incoming log messages)
-# See: https://www.graylog.org/documentation/general/rewriting/
-#rules_file = {{ config.graylog.rules_file }}
 
 # Email transport
 transport_email_enabled = {{ config.graylog.transport_email.enabled }}
 transport_email_hostname = {{ config.graylog.transport_email.hostname }}
 transport_email_port = {{ config.graylog.transport_email.port }}
 transport_email_use_auth = {{ config.graylog.transport_email.use_auth }}
-transport_email_use_tls = {{ config.graylog.transport_email.use_tls }}
-transport_email_use_ssl = {{ config.graylog.transport_email.use_ssl }}
 transport_email_auth_username = {{ config.graylog.transport_email.auth_username }}
 transport_email_auth_password = {{ config.graylog.transport_email.auth_password }}
 transport_email_subject_prefix = {{ config.graylog.transport_email.subject_prefix }}
 transport_email_from_email = {{ config.graylog.transport_email.from_email }}
+
+# Encryption settings
+#
+# ATTENTION:
+#    Using SMTP with STARTTLS *and* SMTPS at the same time is *not* possible.
+
+# Use SMTP with STARTTLS, see https://en.wikipedia.org/wiki/Opportunistic_TLS
+transport_email_use_tls = {{ config.graylog.transport_email.use_tls }}
+
+# Use SMTP over SSL (SMTPS), see https://en.wikipedia.org/wiki/SMTPS
+# This is deprecated on most SMTP services!
+transport_email_use_ssl = {{ config.graylog.transport_email.use_ssl }}
+
 
 # Specify and uncomment this if you want to include links to the stream in your stream alert mails.
 # This should define the fully qualified base url to your web interface exactly the same way as it is accessed by your users.
@@ -533,7 +587,20 @@ transport_email_web_interface_url = {{ config.graylog.transport_email.web_interf
 #http_write_timeout = {{ config.graylog.http_write_timeout }}
 
 # HTTP proxy for outgoing HTTP connections
+# ATTENTION: If you configure a proxy, make sure to also configure the "http_non_proxy_hosts" option so internal
+#            HTTP connections with other nodes does not go through the proxy.
+# Examples:
+#   - http://proxy.example.com:8123
+#   - http://username:password@proxy.example.com:8123
 #http_proxy_uri = {{ config.graylog.http_proxy_uri }}
+
+# A list of hosts that should be reached directly, bypassing the configured proxy server.
+# This is a list of patterns separated by ",". The patterns may start or end with a "*" for wildcards.
+# Any host matching one of these patterns will be reached through a direct connection instead of through a proxy.
+# Examples:
+#   - localhost,127.0.0.1
+#   - 10.0.*,*.example.com
+#http_non_proxy_hosts = {{ config.graylog.http_non_proxy_hosts }}
 
 # Disable the optimization of Elasticsearch indices after index cycling. This may take some load from Elasticsearch
 # on heavily used systems with large indices, but it will decrease search performance. The default is to optimize
@@ -541,12 +608,19 @@ transport_email_web_interface_url = {{ config.graylog.transport_email.web_interf
 #
 # ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
 #            to your previous settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 #disable_index_optimization = {{ config.graylog.disable_index_optimization }}
+
 # Optimize the index down to <= index_optimization_max_num_segments. A higher number may take some load from Elasticsearch
 # on heavily used systems with large indices, but it will decrease search performance. The default is 1.
 #
 # ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
 #            to your previous settings so they will be migrated to the database!
+#            This configuration setting is only used on the first start of Graylog. After that,
+#            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
+#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 #index_optimization_max_num_segments = {{ config.graylog.index_optimization_max_num_segments }}
 
 # The threshold of the garbage collection runs. If GC runs take longer than this threshold, a system notification
@@ -562,25 +636,8 @@ disable_sigar = {{ config.graylog.disable_sigar }}
 # The default cache time for dashboard widgets. (Default: 10 seconds, minimum: 1 second)
 # dashboard_widget_default_cache_time = {{ config.graylog.dashboard_widget_default_cache_time }}
 
-# Message field limit
-# Your web interface can cause high load in your browser when you have a lot of different message fields. The default
-# limit of message fields is 100. Set it to 0 if you always want to get all fields. They are for example used in the
-# search result sidebar or for autocompletion of field names.
-field_list_limit = {{ config.graylog.field_list_limit }}
-
 # Global timeout for communication with Graylog server nodes; default: 5s
 timeout.DEFAULT = {{ config.graylog.timeout_default }}
-
-# Automatically load content packs in "content_packs_dir" on the first start of Graylog.
-content_packs_loader_enabled = {{ config.graylog.content_packs_loader_enabled }}
-
-# The directory which contains content packs which should be loaded on the first start of Graylog.
-content_packs_dir = {{ config.graylog.content_packs_dir }}
-
-# A comma-separated list of content packs (files in "content_packs_dir") which should be applied on
-# the first start of Graylog.
-# Default: empty
-content_packs_auto_load = {{ config.graylog.content_packs_auto_load }}
 
 # For some cluster-related REST requests, the node must query all other nodes in the cluster. This is the maximum number
 # of threads available for this. Increase it, if '/cluster/*' requests take long to complete.

--- a/graylog/map.jinja
+++ b/graylog/map.jinja
@@ -18,38 +18,27 @@
       'root_password_sha2': '',
       'root_email': '',
       'root_timezone': 'UTC',
-      'use_plugins': 'false',
+      'bin_dir': base_dir + '/graylog-server/bin',
+      'data_dir': '/var/lib//graylog-server',
       'plugin_dir': base_dir + '/graylog-server/plugin',
+      'use_plugins': 'false',
       'use_addon_plugins': 'false',
       'addon_plugins': [],
-      'rest':
+      'http':
       {
-        'listen_uri': 'http://127.0.0.1:9000/api/',
-        'transport_uri': 'http://192.168.1.1:9000/api/',
+        'bind_address': '127.0.0.1:9000',
+        'publish_uri': 'http://192.168.1.1:9000/',
+        'external_uri': 'http://192.168.1.1:9000/',
         'enable_cors': 'true',
         'enable_gzip': 'true',
+        'max_header_size': '8192',
+        'thread_pool_size': '16',
         'enable_tls': 'false',
         'tls_cert_file': '/path/to/graylog.crt',
         'tls_key_file': '/path/to/graylog.key',
         'tls_key_password': 'secret',
-        'max_header_size': '8192',
-        'thread_pool_size': '16',
       },
       'trusted_proxies': '127.0.0.1/32, 0:0:0:0:0:0:0:1/128',
-      'web':
-      {
-        'enable': 'true',
-        'listen_uri': 'http://127.0.0.1:9000/',
-        'endpoint_uri': '',
-        'enable_cors': 'true',
-        'enable_gzip': 'true',
-        'enable_tls': 'false',
-        'tls_cert_file': '/path/to/graylog-web.crt',
-        'tls_key_file': '/path/to/graylog-web.key',
-        'tls_key_password': 'secret',
-        'max_header_size': '8192',
-        'thread_pool_size': '16',
-      },
       'rotation_strategy': 'count',
       'no_retention': 'false',
       'retention_strategy': 'delete',
@@ -83,6 +72,7 @@
         'index_optimization_jobs': '20',
       },
       'index_ranges_cleanup_interval': '1h',
+      'index_field_type_periodical_interval': '1h',
       'output_batch_size': '500',
       'output_flush_interval': '1',
       'output_fault_count_threshold': '5',
@@ -124,7 +114,6 @@
         'max_connections': '1000',
         'threads_allowed_to_block_multiplier': '5',
       },
-      'rules_file': '/etc/graylog/server/rules.drl',
       'transport_email':
       {
         'enabled': 'false',
@@ -143,6 +132,7 @@
       'http_read_timeout': '10s',
       'http_write_timeout': '10s',
       'http_proxy_uri': '',
+      'http_non_proxy_hosts': '',
       'disable_index_optimization': 'true',
       'index_optimization_max_num_segments': '1',
       'gc_warning_threshold': '1s',
@@ -151,11 +141,8 @@
       'dashboard_widget_default_cache_time': '10s',
       'field_list_limit': '150',
       'timeout_default': '15s',
-      'content_packs_loader_enabled': 'false',
-      'content_packs_dir': base_dir + '/graylog-server/contentpacks',
-      'content_packs_auto_load': 'grok-patterns.json',
       'proxied_requests_thread_pool_size': '32',
-      'log4j2_log_path': '/var/log/graylog',
+      'log4j2_log_path': '/var/log/graylog-server',
       'input_source': [],
       'heap_size': '1g',
     },
@@ -202,10 +189,10 @@
   {
     'package':
     {
-      'latest_tarball': 'graylog-2.5.2.tgz',
+      'latest_tarball': 'graylog-3.0.0.tgz',
       'install_type': 'package',
-      'repo_version': '2.5',
-      'repo_baseurl': 'https://packages.graylog2.org/repo/el/stable/2.5/$basearch/',
+      'repo_version': '3.0',
+      'repo_baseurl': 'https://packages.graylog2.org/repo/el/stable/3.0/$basearch/',
       'repo_gpgkey': 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-graylog',
       'java_pkg_name': 'java-1.8.0-openjdk-headless'
     }
@@ -214,10 +201,10 @@
   {
     'package':
     {
-      'latest_tarball': 'graylog-2.5.2.tgz',
+      'latest_tarball': 'graylog-3.0.0.tgz',
       'install_type': 'package',
-      'repo_version': '2.5',
-      'repo_baseurl': 'deb https://packages.graylog2.org/repo/debian/ stable 2.5',
+      'repo_version': '3.0',
+      'repo_baseurl': 'deb https://packages.graylog2.org/repo/debian/ stable 3.0',
       'repo_gpgkey': 'https://packages.graylog2.org/repo/debian/pubkey.gpg',
       'java_pkg_name': 'openjdk-8-jdk-headless'
     }

--- a/graylog/map.jinja
+++ b/graylog/map.jinja
@@ -202,7 +202,7 @@
   {
     'package':
     {
-      'latest_tarball': 'graylog-2.4.3.tgz',
+      'latest_tarball': 'graylog-2.4.7.tgz',
       'install_type': 'package',
       'repo_version': '2.4',
       'repo_baseurl': 'https://packages.graylog2.org/repo/el/stable/2.4/$basearch/',
@@ -214,7 +214,7 @@
   {
     'package':
     {
-      'latest_tarball': 'graylog-2.4.3.tgz',
+      'latest_tarball': 'graylog-2.4.7.tgz',
       'install_type': 'package',
       'repo_version': '2.4',
       'repo_baseurl': 'deb https://packages.graylog2.org/repo/debian/ stable 2.4',

--- a/graylog/map.jinja
+++ b/graylog/map.jinja
@@ -202,10 +202,10 @@
   {
     'package':
     {
-      'latest_tarball': 'graylog-2.4.7.tgz',
+      'latest_tarball': 'graylog-2.5.2.tgz',
       'install_type': 'package',
-      'repo_version': '2.4',
-      'repo_baseurl': 'https://packages.graylog2.org/repo/el/stable/2.4/$basearch/',
+      'repo_version': '2.5',
+      'repo_baseurl': 'https://packages.graylog2.org/repo/el/stable/2.5/$basearch/',
       'repo_gpgkey': 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-graylog',
       'java_pkg_name': 'java-1.8.0-openjdk-headless'
     }
@@ -214,10 +214,10 @@
   {
     'package':
     {
-      'latest_tarball': 'graylog-2.4.7.tgz',
+      'latest_tarball': 'graylog-2.5.2.tgz',
       'install_type': 'package',
-      'repo_version': '2.4',
-      'repo_baseurl': 'deb https://packages.graylog2.org/repo/debian/ stable 2.4',
+      'repo_version': '2.5',
+      'repo_baseurl': 'deb https://packages.graylog2.org/repo/debian/ stable 2.5',
       'repo_gpgkey': 'https://packages.graylog2.org/repo/debian/pubkey.gpg',
       'java_pkg_name': 'openjdk-8-jdk-headless'
     }

--- a/pillar.example
+++ b/pillar.example
@@ -8,7 +8,7 @@ firewall:
     default_zone: 'internal'
 
 # Override host options
-# Graylog docs http://docs.graylog.org/en/2.2/
+# Graylog docs http://docs.graylog.org/en/2.4/
 graylog:
   lookup:
     password_secret: '0OckXe4bwAQapvaqbzsugG2DRBRpE3yL5p95O189YUp5a6uKHVS43b0YeHnFcvOPHtXBYDHiXnKbn59TA1TvqwrRWs5mwXpt'
@@ -17,7 +17,7 @@ graylog:
       firewalld:
         status: 'Active'
     package:
-      latest_tarball: 'graylog-2.4.3.tgz'                       # Name of the release tar file if install type is tarball
+      latest_tarball: 'graylog-2.4.7.tgz'                       # Name of the release tar file if install type is tarball
       install_type: 'package'                                   # Install type can be package or tarball    
     {% if grains['os_family'] == 'RedHat' %}
       repo_version: '2.4'

--- a/pillar.example
+++ b/pillar.example
@@ -17,16 +17,16 @@ graylog:
       firewalld:
         status: 'Active'
     package:
-      latest_tarball: 'graylog-2.4.7.tgz'                       # Name of the release tar file if install type is tarball
+      latest_tarball: 'graylog-2.5.2.tgz'                       # Name of the release tar file if install type is tarball
       install_type: 'package'                                   # Install type can be package or tarball    
     {% if grains['os_family'] == 'RedHat' %}
-      repo_version: '2.4'
-      repo_baseurl: 'https://packages.graylog2.org/repo/el/stable/2.4/$basearch/'
+      repo_version: '2.5'
+      repo_baseurl: 'https://packages.graylog2.org/repo/el/stable/2.5/$basearch/'
       repo_gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-graylog'
       java_pkg_name: 'java-1.8.0-openjdk-headless'
     {% elif grains['os_family'] == 'Debian' %}
-      repo_version: '2.4'
-      repo_baseurl: 'deb https://packages.graylog2.org/repo/debian/ stable 2.4'
+      repo_version: '2.5'
+      repo_baseurl: 'deb https://packages.graylog2.org/repo/debian/ stable 2.5'
       repo_gpgkey: 'https://packages.graylog2.org/repo/debian/pubkey.gpg'
       java_pkg_name: 'openjdk-8-jdk-headless'
     {% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -8,7 +8,7 @@ firewall:
     default_zone: 'internal'
 
 # Override host options
-# Graylog docs http://docs.graylog.org/en/2.4/
+# Graylog docs http://docs.graylog.org/en/3.0/
 graylog:
   lookup:
     password_secret: '0OckXe4bwAQapvaqbzsugG2DRBRpE3yL5p95O189YUp5a6uKHVS43b0YeHnFcvOPHtXBYDHiXnKbn59TA1TvqwrRWs5mwXpt'
@@ -17,16 +17,16 @@ graylog:
       firewalld:
         status: 'Active'
     package:
-      latest_tarball: 'graylog-2.5.2.tgz'                       # Name of the release tar file if install type is tarball
+      latest_tarball: 'graylog-3.0.0.tgz'                       # Name of the release tar file if install type is tarball
       install_type: 'package'                                   # Install type can be package or tarball    
     {% if grains['os_family'] == 'RedHat' %}
-      repo_version: '2.5'
-      repo_baseurl: 'https://packages.graylog2.org/repo/el/stable/2.5/$basearch/'
+      repo_version: '3.0'
+      repo_baseurl: 'https://packages.graylog2.org/repo/el/stable/3.0/$basearch/'
       repo_gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-graylog'
       java_pkg_name: 'java-1.8.0-openjdk-headless'
     {% elif grains['os_family'] == 'Debian' %}
-      repo_version: '2.5'
-      repo_baseurl: 'deb https://packages.graylog2.org/repo/debian/ stable 2.5'
+      repo_version: '3.0'
+      repo_baseurl: 'deb https://packages.graylog2.org/repo/debian/ stable 3.0'
       repo_gpgkey: 'https://packages.graylog2.org/repo/debian/pubkey.gpg'
       java_pkg_name: 'openjdk-8-jdk-headless'
     {% endif %}
@@ -40,8 +40,9 @@ graylog:
       use_redirection: 'false'                                  # Redirect port 80 to port 9000
       base_dir: '/usr/share'                                    # /usr/share is default for package install
       log4j2_log_path: '/var/log/graylog-server'                # Path for log files
+      data_dir: '/var/lib//graylog-server'                      # Path for Graylog data
       input_source: ['192.168.2.0/24']                          # Allow network access for sending hosts
-      heap_size: '4g'                                           # Graylog HEAP size default is 1g
+      heap_size: '2g'                                           # Graylog HEAP size default is 1g
       root_timezone: 'America/Chicago'                          # Root users timezone default is UTC
       root_email: 'admin@domain.tld'                            # Root users email
       allow_leading_wildcard_searches: 'true'                   # Use a leading wildcard in searches
@@ -49,18 +50,11 @@ graylog:
       trusted_proxies: '127.0.0.1/32, 0:0:0:0:0:0:0:1/128'      # Trusted proxies
       use_addon_plugins: 'false'                                # Manage additional Graylog plugins
       addon_plugins: [
-                       'graylog-plugin-jabber-2.0.0.jar',
                      ]
-      rest: 
-        listen_uri: 'http://127.0.0.1:9000/api/'                # Rest listen uri external ip if no reverse proxy
-        transport_uri: ''                                       # Rest transport uri
-        enable_cors: 'true'                                     # Enable CORS
-        enable_gzip: 'true'                                     # Enable gzip
-        thread_pool_size: '16'                                  # Rest thread pool size
-      web:
-        enable: 'true'                                          # Enable/Disable web interface
-        listen_uri: 'http://127.0.0.1:9000/'                    # Web listen uri external ip if no reverse proxy
-        endpoint_uri: ''                                        # Web endpoint uri
+      http: 
+        bind_address: '127.0.0.1:9000'                          # HTTP bind address defaults to localhost
+        publish_uri: 'http://192.168.1.1:9000/'                 # URI of Graylog which is used to communicate with other Graylog nodes
+        external_uri: 'http://192.168.1.1:9000/'                # URI which will be used by Graylog to communicate with the Graylog REST API
         enable_cors: 'true'                                     # Enable CORS
         enable_gzip: 'true'                                     # Enable gzip
         thread_pool_size: '16'                                  # Web thread pool size


### PR DESCRIPTION
Bring config template inline with Graylog 3.x changes
Update map.jinja defaults and pillar.example to match new config options for Graylog v3.x
